### PR TITLE
encode uri params

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -36,10 +36,10 @@ module.exports = class FortniteAPI {
             for (var prop in query) {
                 if (Array.isArray(query[prop])) {
                     for (var item of query[prop]) {
-                        params += prop + "=" + item + "&";
+                        params += prop + "=" + encodeURI(item) + "&";
                     }
                 } else {
-                    params += prop + "=" + query[prop] + "&";
+                    params += prop + "=" + encodeURI(query[prop]) + "&";
                 }
             }
             if (params.length > 0) {


### PR DESCRIPTION
to prevent errors with special characters, such as https://discordapp.com/channels/621452110558527502/640574005170143242/745510176886489167