### PR TITLE
Use instance on fetchWithInstance instead of this.axios and remove method from FortniteAPIError

### DIFF
--- a/src/exceptions/FortniteAPIError.ts
+++ b/src/exceptions/FortniteAPIError.ts
@@ -6,11 +6,6 @@ import { FortniteAPIErrorData } from '../http/httpStructs';
  */
 class FortniteAPIError extends Error {
   /**
-   * The HTTP method
-   */
-  public method: string;
-
-  /**
    * The URL of the requested API endpoint
    */
   public url: string;
@@ -35,7 +30,6 @@ class FortniteAPIError extends Error {
     this.name = 'FortniteAPIError';
     this.message = error.error;
 
-    this.method = request.method!.toUpperCase();
     this.url = request.url!;
     this.httpStatus = status;
     this.requestParams = request.params;

--- a/src/exceptions/FortniteAPIError.ts
+++ b/src/exceptions/FortniteAPIError.ts
@@ -6,6 +6,11 @@ import { FortniteAPIErrorData } from '../http/httpStructs';
  */
 class FortniteAPIError extends Error {
   /**
+   * The HTTP method
+   */
+  public method: string;
+  
+  /**
    * The URL of the requested API endpoint
    */
   public url: string;

--- a/src/exceptions/FortniteAPIError.ts
+++ b/src/exceptions/FortniteAPIError.ts
@@ -30,6 +30,7 @@ class FortniteAPIError extends Error {
     this.name = 'FortniteAPIError';
     this.message = error.error;
 
+    this.method = request.method?.toUpperCase() ?? 'GET'
     this.url = request.url!;
     this.httpStatus = status;
     this.requestParams = request.params;

--- a/src/http/HTTP.ts
+++ b/src/http/HTTP.ts
@@ -56,7 +56,7 @@ class HTTP {
           }
         }
 
-        throw new FortniteAPIError(e.response.data, config, e.response.status);
+        throw new FortniteAPIError(e.response.data, e.config ?? config, e.response.status);
       }
 
       throw e;

--- a/src/http/HTTP.ts
+++ b/src/http/HTTP.ts
@@ -43,7 +43,7 @@ class HTTP {
     };
 
     try {
-      const response = await this.axios(config);
+      const response = await instance(config);
 
       return response.data;
     } catch (e) {


### PR DESCRIPTION
The reason for removing method property from FortniteAPIError is that it's never present, and the method is actually static so no point on specifying it on an error. Also, when using CommonJS and requesting a non-existent user's brStats, it will fail but because the ! is not present on the transpiled version of FortniteAPIError, giving an error when using toUpperCase():
```js
[04:10:28.502] ERROR (12272): Error in command "fortnite"
    err: {
      "type": "TypeError",
      "message": "Cannot read properties of undefined (reading 'toUpperCase')",
      "stack":
          TypeError: Cannot read properties of undefined (reading 'toUpperCase')
              at new FortniteAPIError (D:\Coding\Node.js\neru-wa\node_modules\fnapicom\dist\src\exceptions\FortniteAPIError.js:16:38)
              at HTTP.fetchWithInstance (D:\Coding\Node.js\neru-wa\node_modules\fnapicom\dist\src\http\HTTP.js:53:23)
              ...
```

And i noticed the rate-limited axios instance was never used in fetchWithInstance, so i changed that too.

If there's anything wrong tell me.